### PR TITLE
conversion api 추가

### DIFF
--- a/fast-grill-api/src/main/java/com/fastgrill/api/adapter/in/rest/TrackerController.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/adapter/in/rest/TrackerController.java
@@ -1,6 +1,7 @@
 package com.fastgrill.api.adapter.in.rest;
 
 import com.fastgrill.api.application.port.in.ClickCommand;
+import com.fastgrill.api.application.port.in.ConversionCommand;
 import com.fastgrill.api.application.port.in.ImpressionCommand;
 import com.fastgrill.api.application.port.in.TrackerUseCase;
 import com.fastgrill.api.common.resolver.Referer;
@@ -42,7 +43,9 @@ public class TrackerController {
     ) {
         ImpressionCommand command = new ImpressionCommand(shortenToken, referer, userAgent, requestEventId);
         trackerUseCase.impression(command);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 
     @Operation(summary = "클릭 트래킹", description = "시안이 클릭될 때, 호출되는 클릭 트래킹 API")
@@ -63,6 +66,26 @@ public class TrackerController {
         return ResponseEntity
                 .status(HttpStatus.FOUND)
                 .location(URI.create(landingUrl))
+                .build();
+    }
+
+    @Operation(summary = "전환 트래킹", description = "시안이 클릭 후, 원하는 이벤트로 전환되었을 때 호출되는 전환 트래킹 API")
+    @GetMapping(path = "/cvt/{shortenToken}")
+    @Parameters({
+            @Parameter(name = "shortenToken", description = "단축 URL 토큰", example = "RXad41E"),
+            @Parameter(name = "referer", description = "referer url", required = false),
+            @Parameter(name = "userAgent", description = "userAgent", required = false),
+            @Parameter(name = "requestEventId", description = "requestEventId", required = false)
+    })
+    ResponseEntity conversion(@PathVariable("shortenToken") String shortenToken,
+                              @Referer String referer,
+                              @UserAgent String userAgent,
+                              @RequestEventId String requestEventId
+    ) {
+        ConversionCommand command = new ConversionCommand(shortenToken, referer, userAgent, requestEventId);
+        trackerUseCase.convert(command);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
                 .build();
     }
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/adapter/out/messagebroker/TrackingEventProducerAdapter.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/adapter/out/messagebroker/TrackingEventProducerAdapter.java
@@ -2,9 +2,10 @@ package com.fastgrill.api.adapter.out.messagebroker;
 
 import com.fastgrill.api.application.port.out.TrackingEventProducerPort;
 import com.fastgrill.api.domain.ClickEvent;
+import com.fastgrill.api.domain.ConversionEvent;
 import com.fastgrill.api.domain.ImpressionEvent;
-import com.fastgrill.core.shortenurl.domain.Event;
 import com.fastgrill.core.common.PersistenceAdapter;
+import com.fastgrill.core.shortenurl.domain.Event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +22,9 @@ public class TrackingEventProducerAdapter implements TrackingEventProducerPort {
 
     @Value(value = "${kafka.topic.click}")
     private String clickTopic;
+
+    @Value(value = "${kafka.topic.conversion}")
+    private String conversionTopic;
 
     @Override
     public void send(ImpressionEvent event) {
@@ -40,6 +44,17 @@ public class TrackingEventProducerAdapter implements TrackingEventProducerPort {
             log.info("[Kafka enqueued topic: {}, message: {}", clickTopic, event);
         } catch (Exception e) {
             log.error("[Kafka failed topic: {}, message: {}", clickTopic, event);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void send(ConversionEvent event) {
+        try {
+            kafkaTemplate.send(conversionTopic, event);
+            log.info("[Kafka enqueued topic: {}, message: {}", conversionTopic, event);
+        } catch (Exception e) {
+            log.error("[Kafka failed topic: {}, message: {}", conversionTopic, event);
             throw new RuntimeException(e);
         }
     }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ConversionCommand.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ConversionCommand.java
@@ -1,0 +1,35 @@
+package com.fastgrill.api.application.port.in;
+
+import com.fastgrill.api.domain.ConversionEvent;
+import com.fastgrill.core.common.SelfValidating;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ConversionCommand extends SelfValidating<ConversionCommand> {
+    @NotEmpty
+    private final String shortenToken;
+
+    private final String referer;
+
+    @NotNull
+    private final String userAgent;
+
+    private final String requestId;
+
+    public ConversionCommand(String shortenToken, String referer, String userAgent, String requestId) {
+        this.shortenToken = shortenToken;
+        this.referer = referer;
+        this.userAgent = userAgent;
+        this.requestId = requestId;
+        this.validateSelf();
+    }
+
+    public ConversionEvent toEvent() {
+        return new ConversionEvent(requestId, shortenToken, referer, userAgent);
+    }
+}

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/TrackerUseCase.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/TrackerUseCase.java
@@ -3,14 +3,25 @@ package com.fastgrill.api.application.port.in;
 public interface TrackerUseCase {
     /**
      * shorten url 노출 요청 처리
+     *
      * @param command
      */
     void impression(ImpressionCommand command);
 
     /**
      * shorten url click 요청 처리
+     *
      * @param command
      * @return
      */
     String click(ClickCommand command);
+
+
+    /**
+     * shorten url click 후 전환 요청 처리
+     *
+     * @param command
+     * @return
+     */
+    void convert(ConversionCommand command);
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/port/out/TrackingEventProducerPort.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/port/out/TrackingEventProducerPort.java
@@ -1,10 +1,13 @@
 package com.fastgrill.api.application.port.out;
 
 import com.fastgrill.api.domain.ClickEvent;
+import com.fastgrill.api.domain.ConversionEvent;
 import com.fastgrill.api.domain.ImpressionEvent;
 
 public interface TrackingEventProducerPort {
     void send(ImpressionEvent event);
 
     void send(ClickEvent event);
+
+    void send(ConversionEvent event);
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/service/TrackerService.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/service/TrackerService.java
@@ -1,6 +1,7 @@
 package com.fastgrill.api.application.service;
 
 import com.fastgrill.api.application.port.in.ClickCommand;
+import com.fastgrill.api.application.port.in.ConversionCommand;
 import com.fastgrill.api.application.port.in.ImpressionCommand;
 import com.fastgrill.api.application.port.in.TrackerUseCase;
 import com.fastgrill.api.application.port.out.ShortenUrlPort;
@@ -23,8 +24,8 @@ public class TrackerService implements TrackerUseCase {
 
     @Override
     public void impression(ImpressionCommand command) {
-        var impressionEvent = command.toEvent();
-        trackingEventProducerPort.send(impressionEvent);
+        var event = command.toEvent();
+        trackingEventProducerPort.send(event);
     }
 
     @Override
@@ -34,9 +35,15 @@ public class TrackerService implements TrackerUseCase {
 
         shortenUrlHitsPort.increaseHits(command.getShortenToken());
 
-        var clickEvent = command.toEvent();
-        trackingEventProducerPort.send(clickEvent);
+        var event = command.toEvent();
+        trackingEventProducerPort.send(event);
 
         return clickUrl.getOriginUrl();
+    }
+
+    @Override
+    public void convert(ConversionCommand command) {
+        var event = command.toEvent();
+        trackingEventProducerPort.send(event);
     }
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/domain/ConversionEvent.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/domain/ConversionEvent.java
@@ -1,0 +1,21 @@
+package com.fastgrill.api.domain;
+
+
+import com.fastgrill.core.shortenurl.domain.Event;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ConversionEvent extends Event {
+    private String shortenToken;
+    private String referer;
+    private String userAgent;
+
+    public ConversionEvent(String id, String shortenToken, String referer, String userAgent) {
+        super(id);
+        this.shortenToken = shortenToken;
+        this.referer = referer;
+        this.userAgent = userAgent;
+    }
+}

--- a/fast-grill-core/src/main/resources/application.yml
+++ b/fast-grill-core/src/main/resources/application.yml
@@ -34,3 +34,4 @@ kafka:
   topic:
     impression: fastgrill.impression
     click: fastgrill.click
+    conversion: fastgrill.conversion


### PR DESCRIPTION
click <> conversion event 의 발생 기간이 특정 시간 미만인 경우, 전환수를 집계하는 용도로 사용하기 위해 
conversion api를 추가. 

event 간의 발생 기간을 추적하는 로직을 개발하고자 한 배경은,
kafka streams와 join 기능을 사용해보기 위함임.
