### PR TITLE
event tracking용 식별자 파라미터 추가

### DIFF
--- a/fast-grill-api/src/main/java/com/fastgrill/api/adapter/in/rest/TrackerController.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/adapter/in/rest/TrackerController.java
@@ -14,10 +14,7 @@ import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -29,19 +26,21 @@ public class TrackerController {
     private final TrackerUseCase trackerUseCase;
 
     @Operation(summary = "노출 트래킹", description = "시안이 노출될 때, 호출되는 노출 트래킹 API")
-    @GetMapping(path = "/imp/{shortenToken}")
+    @GetMapping(path = "/impression/{shortenToken}")
     @Parameters({
             @Parameter(name = "shortenToken", description = "단축 URL 토큰", example = "RXad41E"),
+            @Parameter(name = "trackId", description = "이벤트 트래킹 고유 식별자", example = "6c108a57-9801-40fd-90b7-dbcbfd49dd4b"),
             @Parameter(name = "referer", description = "referer url", required = false),
             @Parameter(name = "userAgent", description = "userAgent", required = false),
             @Parameter(name = "requestEventId", description = "requestEventId", required = false)
     })
     ResponseEntity<Void> impression(@PathVariable("shortenToken") String shortenToken,
+                                    @RequestParam String trackId,
                                     @Referer String referer,
                                     @UserAgent String userAgent,
                                     @RequestEventId String requestEventId
     ) {
-        ImpressionCommand command = new ImpressionCommand(shortenToken, referer, userAgent, requestEventId);
+        ImpressionCommand command = new ImpressionCommand(shortenToken, trackId, referer, userAgent, requestEventId);
         trackerUseCase.impression(command);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
@@ -49,19 +48,21 @@ public class TrackerController {
     }
 
     @Operation(summary = "클릭 트래킹", description = "시안이 클릭될 때, 호출되는 클릭 트래킹 API")
-    @GetMapping(path = "/clk/{shortenToken}")
+    @GetMapping(path = "/click/{shortenToken}")
     @Parameters({
             @Parameter(name = "shortenToken", description = "단축 URL 토큰", example = "RXad41E"),
-            @Parameter(name = "referer", description = "referer url", required = false),
-            @Parameter(name = "userAgent", description = "userAgent", required = false),
-            @Parameter(name = "requestEventId", description = "requestEventId", required = false)
+            @Parameter(name = "trackId", description = "이벤트 트래킹 고유 식별자", example = "6c108a57-9801-40fd-90b7-dbcbfd49dd4b"),
+            @Parameter(name = "referer", description = "referer url"),
+            @Parameter(name = "userAgent", description = "userAgent"),
+            @Parameter(name = "requestEventId", description = "requestEventId")
     })
     ResponseEntity click(@PathVariable("shortenToken") String shortenToken,
+                         @RequestParam String trackId,
                          @Referer String referer,
                          @UserAgent String userAgent,
                          @RequestEventId String requestEventId
     ) {
-        ClickCommand command = new ClickCommand(shortenToken, referer, userAgent, requestEventId);
+        ClickCommand command = new ClickCommand(shortenToken, trackId, referer, userAgent, requestEventId);
         String landingUrl = trackerUseCase.click(command);
         return ResponseEntity
                 .status(HttpStatus.FOUND)
@@ -70,19 +71,21 @@ public class TrackerController {
     }
 
     @Operation(summary = "전환 트래킹", description = "시안이 클릭 후, 원하는 이벤트로 전환되었을 때 호출되는 전환 트래킹 API")
-    @GetMapping(path = "/cvt/{shortenToken}")
+    @GetMapping(path = "/conversion/{shortenToken}")
     @Parameters({
             @Parameter(name = "shortenToken", description = "단축 URL 토큰", example = "RXad41E"),
+            @Parameter(name = "trackId", description = "이벤트 트래킹 고유 식별자", example = "6c108a57-9801-40fd-90b7-dbcbfd49dd4b"),
             @Parameter(name = "referer", description = "referer url", required = false),
             @Parameter(name = "userAgent", description = "userAgent", required = false),
             @Parameter(name = "requestEventId", description = "requestEventId", required = false)
     })
     ResponseEntity conversion(@PathVariable("shortenToken") String shortenToken,
+                              @RequestParam String trackId,
                               @Referer String referer,
                               @UserAgent String userAgent,
                               @RequestEventId String requestEventId
     ) {
-        ConversionCommand command = new ConversionCommand(shortenToken, referer, userAgent, requestEventId);
+        ConversionCommand command = new ConversionCommand(shortenToken, trackId, referer, userAgent, requestEventId);
         trackerUseCase.convert(command);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ClickCommand.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ClickCommand.java
@@ -14,6 +14,9 @@ public class ClickCommand extends SelfValidating<ClickCommand> {
     @NotEmpty
     private final String shortenToken;
 
+    @NotEmpty
+    private final String trackId;
+
     private final String referer;
 
     @NotNull
@@ -21,8 +24,9 @@ public class ClickCommand extends SelfValidating<ClickCommand> {
 
     private final String requestId;
 
-    public ClickCommand(String shortenToken, String referer, String userAgent, String requestId) {
+    public ClickCommand(String shortenToken, String trackId, String referer, String userAgent, String requestId) {
         this.shortenToken = shortenToken;
+        this.trackId = trackId;
         this.referer = referer;
         this.userAgent = userAgent;
         this.requestId = requestId;
@@ -30,6 +34,6 @@ public class ClickCommand extends SelfValidating<ClickCommand> {
     }
 
     public ClickEvent toEvent() {
-        return new ClickEvent(requestId, shortenToken, referer, userAgent);
+        return new ClickEvent(requestId, trackId, shortenToken, referer, userAgent);
     }
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ConversionCommand.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ConversionCommand.java
@@ -14,6 +14,9 @@ public class ConversionCommand extends SelfValidating<ConversionCommand> {
     @NotEmpty
     private final String shortenToken;
 
+    @NotEmpty
+    private final String trackId;
+
     private final String referer;
 
     @NotNull
@@ -21,8 +24,9 @@ public class ConversionCommand extends SelfValidating<ConversionCommand> {
 
     private final String requestId;
 
-    public ConversionCommand(String shortenToken, String referer, String userAgent, String requestId) {
+    public ConversionCommand(String shortenToken, String trackId, String referer, String userAgent, String requestId) {
         this.shortenToken = shortenToken;
+        this.trackId = trackId;
         this.referer = referer;
         this.userAgent = userAgent;
         this.requestId = requestId;
@@ -30,6 +34,6 @@ public class ConversionCommand extends SelfValidating<ConversionCommand> {
     }
 
     public ConversionEvent toEvent() {
-        return new ConversionEvent(requestId, shortenToken, referer, userAgent);
+        return new ConversionEvent(requestId, shortenToken, trackId, referer, userAgent);
     }
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ImpressionCommand.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/application/port/in/ImpressionCommand.java
@@ -1,6 +1,5 @@
 package com.fastgrill.api.application.port.in;
 
-import com.fastgrill.api.domain.ClickEvent;
 import com.fastgrill.api.domain.ImpressionEvent;
 import com.fastgrill.core.common.SelfValidating;
 import lombok.EqualsAndHashCode;
@@ -15,6 +14,9 @@ public class ImpressionCommand extends SelfValidating<ImpressionCommand> {
     @NotEmpty
     private final String shortenToken;
 
+    @NotEmpty
+    private final String trackId;
+
     private final String referer;
 
     @NotNull
@@ -22,8 +24,9 @@ public class ImpressionCommand extends SelfValidating<ImpressionCommand> {
 
     private final String requestId;
 
-    public ImpressionCommand(String shortenToken, String referer, String userAgent, String requestId) {
+    public ImpressionCommand(String shortenToken, String trackId, String referer, String userAgent, String requestId) {
         this.shortenToken = shortenToken;
+        this.trackId = trackId;
         this.referer = referer;
         this.userAgent = userAgent;
         this.requestId = requestId;
@@ -31,6 +34,6 @@ public class ImpressionCommand extends SelfValidating<ImpressionCommand> {
     }
 
     public ImpressionEvent toEvent() {
-        return new ImpressionEvent(requestId, shortenToken, referer, userAgent);
+        return new ImpressionEvent(requestId, shortenToken, trackId, referer, userAgent);
     }
 }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/domain/ClickEvent.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/domain/ClickEvent.java
@@ -9,12 +9,14 @@ import lombok.ToString;
 @ToString
 public class ClickEvent extends Event {
     private String shortenToken;
+    private String trackId;
     private String referer;
     private String userAgent;
 
-    public ClickEvent(String id, String shortenToken, String referer, String userAgent) {
+    public ClickEvent(String id, String shortenToken, String trackId, String referer, String userAgent) {
         super(id);
         this.shortenToken = shortenToken;
+        this.trackId = trackId;
         this.referer = referer;
         this.userAgent = userAgent;
     }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/domain/ConversionEvent.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/domain/ConversionEvent.java
@@ -9,12 +9,14 @@ import lombok.ToString;
 @ToString
 public class ConversionEvent extends Event {
     private String shortenToken;
+    private String trackId;
     private String referer;
     private String userAgent;
 
-    public ConversionEvent(String id, String shortenToken, String referer, String userAgent) {
+    public ConversionEvent(String id, String shortenToken, String trackId, String referer, String userAgent) {
         super(id);
         this.shortenToken = shortenToken;
+        this.trackId = trackId;
         this.referer = referer;
         this.userAgent = userAgent;
     }

--- a/fast-grill-api/src/main/java/com/fastgrill/api/domain/ImpressionEvent.java
+++ b/fast-grill-api/src/main/java/com/fastgrill/api/domain/ImpressionEvent.java
@@ -9,12 +9,14 @@ import lombok.ToString;
 @ToString
 public class ImpressionEvent extends Event {
     private String shortenToken;
+    private String trackId;
     private String referer;
     private String userAgent;
 
-    public ImpressionEvent(String id, String shortenToken, String referer, String userAgent) {
+    public ImpressionEvent(String id, String shortenToken, String trackId, String referer, String userAgent) {
         super(id);
         this.shortenToken = shortenToken;
+        this.trackId = trackId;
         this.referer = referer;
         this.userAgent = userAgent;
     }


### PR DESCRIPTION
impression -> click -> conversion 전환 트래킹을 위한 track Id 추가.
이걸 기반으로 click/conversion event를 kafka stream으로 join할 예정.

### 나중에 고쳐야할 거
request header 값을 파싱해서 쓰는 값들이 스웨거에 필수값으로 되어있음.
required=false으로 설정해두었는데도 필수로 뜸. 
![스크린샷 2023-03-25 오후 5 26 54](https://user-images.githubusercontent.com/10669355/227706308-89068650-cb13-4d04-ba30-f6a7433698f7.png)
